### PR TITLE
[refactor/BE] @PreAuthorize 어노테이션을 이용하여, 로그인한 사용자의 권한에 따라 엔드포인트 접근을 허용한다

### DIFF
--- a/src/main/java/com/hallym/rehab/domain/program/controller/ProgramAdminController.java
+++ b/src/main/java/com/hallym/rehab/domain/program/controller/ProgramAdminController.java
@@ -5,6 +5,8 @@ import com.hallym.rehab.domain.program.service.ProgramService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -17,23 +19,25 @@ public class ProgramAdminController {
 
     private final ProgramService programService;
 
-//    @PreAuthorize("authentication.principal.username == #passwordChangeDTO.mid or hasRole('ROLE_ADMIN')")
+    @PreAuthorize("authentication.principal.username == #programRequestDTO.mid or hasRole('ROLE_ADMIN')")
     @PostMapping("/create")
-    public Map<String, Long> createProgram(@ModelAttribute ProgramRequestDTO programRequestDTO) {
+    public Map<String, Long> createProgram(@RequestBody ProgramRequestDTO programRequestDTO) {
         Long result = programService.createProgram(programRequestDTO);
         return Map.of("Program number : ", result);
     }
 
+    @PreAuthorize("authentication.principal.username == #programRequestDTO.mid or hasRole('ROLE_ADMIN')")
     @PutMapping("/modify/{pno}")
     public ResponseEntity<String> modifyProgram(@PathVariable Long pno,
-                                                @ModelAttribute ProgramRequestDTO programRequestDTO) {
+                                                @RequestBody ProgramRequestDTO programRequestDTO) {
         String result = programService.modifyProgramOne(pno, programRequestDTO);
         return ResponseEntity.ok(result);
     }
 
+    @PreAuthorize("authentication.principal.username == #programRequestDTO.mid or hasRole('ROLE_ADMIN')")
     @DeleteMapping("/delete/{pno}")
-    public ResponseEntity<String> deleteProgram(@PathVariable Long pno) {
-        String result = programService.deleteProgramOne(pno);
+    public ResponseEntity<String> deleteProgram(@PathVariable Long pno, @RequestBody ProgramRequestDTO programRequestDTO) {
+        String result = programService.deleteProgramOne(pno, programRequestDTO);
         return ResponseEntity.ok(result);
     }
 

--- a/src/main/java/com/hallym/rehab/domain/program/controller/ProgramUserController.java
+++ b/src/main/java/com/hallym/rehab/domain/program/controller/ProgramUserController.java
@@ -12,7 +12,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
 import java.util.List;
 
 @Slf4j
@@ -33,6 +32,7 @@ public class ProgramUserController {
         return programService.getProgramOne(pno, mid);
     }
 
+    @PreAuthorize("authentication.principal.username == #programHistoryDTO.mid or hasRole('ROLE_ADMIN')")
     @PostMapping("/addHistory/{pno}")
     public ResponseEntity<String> takeAProgram(@PathVariable Long pno, @RequestBody ProgramHistoryDTO programHistoryDTO) {
         String mid = programHistoryDTO.getMid();
@@ -40,6 +40,7 @@ public class ProgramUserController {
         return ResponseEntity.ok(result);
     }
 
+    @PreAuthorize("authentication.principal.username == #programHistoryDTO.mid or hasRole('ROLE_ADMIN')")
     @DeleteMapping("/delete/{pno}")
     public ResponseEntity<String> cancelProgram(@PathVariable Long pno, @RequestBody ProgramHistoryDTO programHistoryDTO) {
         String mid = programHistoryDTO.getMid();
@@ -47,12 +48,14 @@ public class ProgramUserController {
         return ResponseEntity.ok(result);
     }
 
+    @PreAuthorize("authentication.principal.username == #programHistoryDTO.mid or hasRole('ROLE_ADMIN')")
     @GetMapping("/history/{pno}")
     public ProgramHistoryDTO getHistoryOne(@PathVariable Long pno, @RequestBody ProgramHistoryDTO programHistoryDTO) {
         String mid = programHistoryDTO.getMid();
         return programService.getProgramHistoryOne(pno, mid);
     }
 
+    @PreAuthorize("authentication.principal.username == #programHistoryDTO.mid or hasRole('ROLE_ADMIN')")
     @GetMapping("/history/list")
     public List<ProgramListResponseDTO> getProgramHistoryList(@RequestBody ProgramHistoryDTO programHistoryDTO) {
         String mid = programHistoryDTO.getMid();

--- a/src/main/java/com/hallym/rehab/domain/program/controller/VideoAdminController.java
+++ b/src/main/java/com/hallym/rehab/domain/program/controller/VideoAdminController.java
@@ -8,7 +8,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Map;
 
 @Slf4j
 @RestController
@@ -18,7 +17,6 @@ public class VideoAdminController {
 
     private final VideoService videoService;
 
-    //    @PreAuthorize("authentication.principal.username == #passwordChangeDTO.mid or hasRole('ROLE_ADMIN')")
     @PostMapping("/create/{pno}/{ord}")
     public ResponseEntity<String> createVideo(@PathVariable Long pno,
                                               @PathVariable Long ord,

--- a/src/main/java/com/hallym/rehab/domain/program/controller/VideoUserController.java
+++ b/src/main/java/com/hallym/rehab/domain/program/controller/VideoUserController.java
@@ -6,6 +6,7 @@ import com.hallym.rehab.domain.program.service.VideoService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -21,9 +22,10 @@ public class VideoUserController {
         return videoService.getVideoList(pno);
     }
 
+    @PreAuthorize("authentication.principal.username == #metricsRequestDTO.mid or hasRole('ROLE_ADMIN')")
     @PutMapping("/modify/metrics/{vno}")
     public ResponseEntity<String> saveMetrics(@PathVariable Long vno,
-                                             @ModelAttribute MetricsRequestDTO metricsRequestDTO) {
+                                             @RequestBody MetricsRequestDTO metricsRequestDTO) {
         String result = videoService.saveMetrics(vno, metricsRequestDTO);
         return ResponseEntity.ok(result);
     }

--- a/src/main/java/com/hallym/rehab/domain/program/dto/program/ProgramRequestDTO.java
+++ b/src/main/java/com/hallym/rehab/domain/program/dto/program/ProgramRequestDTO.java
@@ -2,14 +2,15 @@ package com.hallym.rehab.domain.program.dto.program;
 
 import com.hallym.rehab.domain.program.entity.Category;
 import com.hallym.rehab.domain.program.entity.Position;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
+@Data
 @Getter
-@Setter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class ProgramRequestDTO {
+    private String mid;
     private String programTitle;
     private String description;
     private Category category;

--- a/src/main/java/com/hallym/rehab/domain/program/entity/Program.java
+++ b/src/main/java/com/hallym/rehab/domain/program/entity/Program.java
@@ -1,6 +1,7 @@
 package com.hallym.rehab.domain.program.entity;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.hallym.rehab.domain.user.entity.Member;
 import com.hallym.rehab.global.baseEntity.BaseTimeEntity;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
@@ -32,6 +33,10 @@ public class Program extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     private Position position;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mid")
+    private Member member;
 
     @Builder.Default
     @OneToMany(mappedBy = "program", fetch = FetchType.LAZY)

--- a/src/main/java/com/hallym/rehab/domain/program/entity/Video.java
+++ b/src/main/java/com/hallym/rehab/domain/program/entity/Video.java
@@ -61,16 +61,4 @@ public class Video extends BaseTimeEntity {
         this.ord = ord;
     }
 
-    public void changeProgramVideo(String GuideVideoURL, String JsonURL,
-                                   String GuideVideoObjectPath, String JsonObjectPath, Long ord) {
-        this.GuideVideoURL = GuideVideoURL;
-        this.JsonURL = JsonURL;
-        this.GuideVideoObjectPath = GuideVideoObjectPath;
-        this.JsonObjectPath = JsonObjectPath;
-        this.ord = ord;
-    }
-
-    public void changeProgram(Program program){ //Program 엔티티 삭제 시 ProgramVideo 객체의 참조도 변경하기 위한 메소드
-        this.program = program;
-    }
 }

--- a/src/main/java/com/hallym/rehab/domain/program/service/ProgramService.java
+++ b/src/main/java/com/hallym/rehab/domain/program/service/ProgramService.java
@@ -7,11 +7,14 @@ import com.hallym.rehab.domain.program.dto.program.ProgramListResponseDTO;
 import com.hallym.rehab.domain.program.dto.program.ProgramRequestDTO;
 import com.hallym.rehab.domain.program.entity.Program;
 
+import com.hallym.rehab.domain.user.entity.Member;
+import com.hallym.rehab.domain.user.repository.MemberRepository;
 import com.hallym.rehab.global.pageDTO.PageRequestDTO;
 import com.hallym.rehab.global.pageDTO.PageResponseDTO;
 
 import java.util.Comparator;
 import java.util.List;
+
 
 
 public interface ProgramService {
@@ -25,7 +28,7 @@ public interface ProgramService {
 
     String modifyProgramOne(Long pno, ProgramRequestDTO programRequestDTO);
 
-    String deleteProgramOne(Long pno);
+    String deleteProgramOne(Long pno, ProgramRequestDTO programRequestDTO);
 
     Long createProgram(ProgramRequestDTO programRequestDTO);
 
@@ -33,27 +36,4 @@ public interface ProgramService {
 
     String cancelProgram(Long pno, String mid);
 
-    default Program programRequestDtoToProgram(ProgramRequestDTO programRequestDTO) {
-
-        return Program.builder()
-                .programTitle(programRequestDTO.getProgramTitle())
-                .description(programRequestDTO.getDescription())
-                .category(programRequestDTO.getCategory())
-                .position(programRequestDTO.getPosition())
-                .build();
-    }
-    default ProgramDetailResponseDTO entitesToProgramDetailResponseDTO(Program program, List<ActResponseDTO> actResponseDTOList){
-
-        actResponseDTOList.sort(Comparator.comparing(ActResponseDTO::getOrd));
-
-        return ProgramDetailResponseDTO.builder()
-                .pno(program.getPno())
-                .programTitle(program.getProgramTitle())
-                .description(program.getDescription())
-                .category(program.getCategory())
-                .position(program.getPosition())
-                .actResponseDTO(actResponseDTOList)
-                .regDate(program.getRegDate())
-                .build();
-    }
 }

--- a/src/main/java/com/hallym/rehab/domain/program/service/ProgramServiceImpl.java
+++ b/src/main/java/com/hallym/rehab/domain/program/service/ProgramServiceImpl.java
@@ -23,10 +23,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Log4j2
@@ -133,7 +130,7 @@ public class ProgramServiceImpl implements ProgramService{
     }
 
     @Override
-    public String deleteProgramOne(Long pno) {
+    public String deleteProgramOne(Long pno, ProgramRequestDTO programRequestDTO) {
         Program program = programRepository.findById(pno)
                 .orElseThrow(() -> new RuntimeException("Program not found for Id : " + pno));
 
@@ -179,7 +176,6 @@ public class ProgramServiceImpl implements ProgramService{
     @Override
     public Long createProgram(ProgramRequestDTO programRequestDTO) {
         Program program = programRequestDtoToProgram(programRequestDTO);
-
         programRepository.save(program);
 
         return program.getPno();
@@ -219,5 +215,36 @@ public class ProgramServiceImpl implements ProgramService{
 
         programHistoryRepository.delete(programHistory);
         return "Program Cancel Success for Member Id : " + mid;
+    }
+
+
+    protected Program programRequestDtoToProgram(ProgramRequestDTO programRequestDTO) {
+
+        Member member = memberRepository.findById(programRequestDTO.getMid())
+                .orElseThrow(() -> new RuntimeException("Member not found for Id : " + programRequestDTO.getMid()));
+
+
+        return Program.builder()
+                .member(member)
+                .programTitle(programRequestDTO.getProgramTitle())
+                .description(programRequestDTO.getDescription())
+                .category(programRequestDTO.getCategory())
+                .position(programRequestDTO.getPosition())
+                .build();
+    }
+
+    protected ProgramDetailResponseDTO entitesToProgramDetailResponseDTO(Program program, List<ActResponseDTO> actResponseDTOList){
+
+        actResponseDTOList.sort(Comparator.comparing(ActResponseDTO::getOrd));
+
+        return ProgramDetailResponseDTO.builder()
+                .pno(program.getPno())
+                .programTitle(program.getProgramTitle())
+                .description(program.getDescription())
+                .category(program.getCategory())
+                .position(program.getPosition())
+                .actResponseDTO(actResponseDTOList)
+                .regDate(program.getRegDate())
+                .build();
     }
 }

--- a/src/main/java/com/hallym/rehab/domain/user/controller/UserController.java
+++ b/src/main/java/com/hallym/rehab/domain/user/controller/UserController.java
@@ -9,6 +9,8 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,10 +36,20 @@ public class UserController {
         }
     }
 
-    @PreAuthorize("authentication.principal.username == #passwordChangeDTO.mid or hasRole('ROLE_ADMIN')")
+    @PreAuthorize("authentication.principal.username == #passwordChangeDTO.mid")
     @PostMapping("/auth/change-password")
     public ResponseEntity<String> changePassword(@RequestBody PasswordChangeDTO passwordChangeDTO) {
+
+        String securityContextHolder = SecurityContextHolder.getContext().getAuthentication().getName();
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        UserDetails userDetails =(UserDetails) principal;
+        log.info("----getname-" + securityContextHolder);
+        log.info("---prin--" + userDetails.getUsername());
+
+        log.info("---------" + passwordChangeDTO.getMid());
         String username = passwordChangeDTO.getMid();
+
         try {
             apiUserService.changePassword(username, passwordChangeDTO);
             return ResponseEntity.ok("비밀번호 변경 완료");


### PR DESCRIPTION
## ☑️ Describe your changes
- Program과 Video 도메인을 분리했기 때문에, 더이상 사용하지 않는 Video 엔티티 내부 메소드 삭제
- DTO와 Entity 변환 메소드를 인터페이스가 아닌 구현체 클래스로 이동
- `@PreAuthorize` 어노테이션을 이용한 엔드포인트 인증처리
- 생성자가 누락된 DTO에  lombok 처리 및 필요한 엔티티에 필드 추가 

## 📷 Screenshot
<img width="631" alt="image" src="https://github.com/ReHab-Web/ReHab-Backend/assets/80760160/91464d40-7722-4863-b483-bf224c5fc423">

## 🔗 Issue number and link
- closed #24 