### PR TITLE
[fix/BE] Video 목록 조회 테스트 시, 메소드 명 오류를 해결한다.

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -7,14 +7,15 @@
 
 name: Java CI with Gradle
 
-on:
+on: # 워크플로를 언제 실행할지를 정의
   push:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 
-permissions:
-  contents: read
+permissions: # 워크플로의 권한을 설정
+  contents: read # 코드 리포지토리의 내용을 읽기 권한을 부여
+  checks: write # 워크플로 결과를 체크하기 위한 쓰기 권한을 부여
 
 jobs:
   build:
@@ -30,7 +31,7 @@ jobs:
         java-version: '11'
         distribution: 'temurin'
 
-    # gradle build를 위한 permission 획득
+    # Gradle Wrapper 스크립트를 실행하기 위한 permission 획득
     - name: Run chmod to make gradlew executable
       run: chmod +x ./gradlew
 
@@ -44,7 +45,7 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_EC2_METADATA_DISABLED: true
-      run: aws s3 sync --delete --region ap-northeast-2 build s3://rehab
+      run: aws s3 sync --delete --region ap-northeast-2 build s3://rehab #AWS CLI를 사용하여 로컬 빌드를 S3 버킷에 동기화
 
     - name: 테스트 결과를 PR에 코멘트로 등록합니다
       uses: EnricoMi/publish-unit-test-result-action@v1

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -37,9 +37,9 @@ jobs:
 
     # gradle build
     - name: Build with Gradle
-      run: ./gradlew build
+      run: ./gradlew build --warning-mode=all --stacktrace
 
-    # AWS CLI command로 objectStorage에 배포
+      # AWS CLI command로 objectStorage에 배포
     - name: Sync Bucket
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/src/test/java/com/hallym/rehab/domain/program/service/VideoServiceImplTest.java
+++ b/src/test/java/com/hallym/rehab/domain/program/service/VideoServiceImplTest.java
@@ -100,7 +100,7 @@ class VideoServiceImplTest {
         //when
         VideoResponseDTO videoList = videoService.getVideoList(pno);
         //then
-        assertThat(videoList.getProgramVideoFile().size()).isEqualTo(1);
+        assertThat(videoList.getVno_videoUrl().size()).isEqualTo(1);
     }
 
     @Test


### PR DESCRIPTION
- VideoServiceImplTest 테스트 실행 시  ProgramVideoFile이 vno_videoUrl로 변경된 부분 수정

## ☑️ Describe your changes
- VideoResponseDTO에 ProgramVideoFile 필드가 vno_videoUrl로 변경되었기 때문에 VideoServiceImplTest에 getVideoList() 테스트 실행 시 getter 사용 메소드의 필드명을 변경했습니다.

## 📷 Screenshot
<img width="459" alt="image" src="https://github.com/ReHab-Web/ReHab-Backend/assets/80760160/a53b0d36-9419-46f7-bffc-ddfde5efd668">

## 🔗 Issue number and link
- 이슈 번호를 등록해주세요
> closed {#이슈번호}